### PR TITLE
Log Rotation based on size and time 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ cover/
 
 # Django stuff:
 *.log
+*.log.*
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/mmdt/mmdt/settings.py
+++ b/mmdt/mmdt/settings.py
@@ -177,39 +177,27 @@ if not os.path.exists(log_dir):
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '{levelname} {asctime} {module} {message}',
-            'style': '{',
-        },
-    },
     'handlers': {
-        'rotate_file': {
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.path.join(log_dir, 'django_rotated.log'),
-            'mode': 'a',
-            'maxBytes': 5 * 1024 * 1024, # if exceeds 5MB, a new log file will be created
-            'backupCount': 5,
-            'formatter': 'verbose',
-        },
         'timed_rotate_file': {
             'class': 'logging.handlers.TimedRotatingFileHandler',
             'filename': os.path.join(log_dir, 'django_timed.log'),
-            'when': 'midnight', # rotate log file at midnight
-            'interval': 1, # rotate log file every day
-            'backupCount': 5,
+            'when': 'midnight',  # Rotate log file at midnight, effectively once a day
+            'interval': 1,  # Interval set to 1, combined with 'midnight' means once a day
+            'backupCount': 30,  # Keep last 5 files
             'formatter': 'verbose',
+        },
+    },
+    'formatters': {
+        'verbose': {
+            'format': '{levelname} {asctime} {module} {process:d} {thread:d} {message}',
+            'style': '{',
         },
     },
     'loggers': {
         'django': {
-            'handlers': ['rotate_file', 'timed_rotate_file'],
+            'handlers': ['timed_rotate_file'],
             'level': 'INFO',
             'propagate': True,
         },
-    },
-    'root': {
-        'handlers': ['rotate_file', 'timed_rotate_file'],
-        'level': 'INFO',
     },
 }

--- a/mmdt/mmdt/settings.py
+++ b/mmdt/mmdt/settings.py
@@ -185,16 +185,31 @@ LOGGING = {
     },
     'handlers': {
         'rotate_file': {
-            'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': os.path.join(log_dir, 'django.log'),
-            'maxBytes': 10 * 1024 * 1024,
+            'filename': os.path.join(log_dir, 'django_rotated.log'),
+            'mode': 'a',
+            'maxBytes': 5 * 1024 * 1024, # if exceeds 5MB, a new log file will be created
+            'backupCount': 5,
+            'formatter': 'verbose',
+        },
+        'timed_rotate_file': {
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': os.path.join(log_dir, 'django_timed.log'),
+            'when': 'midnight', # rotate log file at midnight
+            'interval': 1, # rotate log file every day
             'backupCount': 5,
             'formatter': 'verbose',
         },
     },
+    'loggers': {
+        'django': {
+            'handlers': ['rotate_file', 'timed_rotate_file'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
     'root': {
-        'handlers': ['rotate_file'],
+        'handlers': ['rotate_file', 'timed_rotate_file'],
         'level': 'INFO',
     },
 }


### PR DESCRIPTION
- This is the PR for the issue https://github.com/khinezarthwe/mmdt_web_app/issues/72

### Things I modified
- I have solved the problem of log file size growing without rotation by capping the file size to 5MB.
- If the file size exceeds its limitation, a new log file will be created.
- Secondly, I added the new handler called `timed_rotate_file` using `TimeRotatingFileHandler` to rotate the log file depending on time (every midnight).

### Research Findings
- However, the log file rotations work on my PC only when I run with this command `python manage.py runserver --noreload`. I found the solution on this [link](https://stackoverflow.com/questions/26830918/django-logging-rotating-files-not-working)
- Also due to my findings, I found out that it is more relevant to use Custom Handler or a third-party library that supports concurrent log handling. But I have no capacity to write a custom handler by myself and also a third-party library called `ConcurrentLogHandler` does not support Python 3.10 and later.