### PR TITLE
Adding enabled and disabled feature for the selected questions

### DIFF
--- a/mmdt/polls/admin.py
+++ b/mmdt/polls/admin.py
@@ -4,7 +4,6 @@ from django.contrib import admin
 
 from .models import Question, Choice
 
-
 class ChoiceInline(admin.TabularInline):
     model = Choice
     extra = 3
@@ -43,7 +42,15 @@ class QuestionAdmin(admin.ModelAdmin):
     list_display = ["question_text", "pub_date", "was_published_recently", "is_enabled"]
     list_filter = ["pub_date", "is_enabled"]
     search_fields = ["question_text"]
-    actions = [export_to_csv]
+    actions = [export_to_csv, 'enable_questions', 'disable_questions']
+
+    def enable_questions(self, request, queryset):
+        queryset.update(is_enabled=True)
+    enable_questions.short_description = 'Enable selected questions'
+
+    def disable_questions(self, request, queryset):
+        queryset.update(is_enabled=False)
+    disable_questions.short_description = 'Disable selected questions'
 
 admin.site.register(Question, QuestionAdmin)
 admin.site.register(Choice)

--- a/mmdt/polls/admin.py
+++ b/mmdt/polls/admin.py
@@ -54,5 +54,3 @@ class QuestionAdmin(admin.ModelAdmin):
 
 admin.site.register(Question, QuestionAdmin)
 admin.site.register(Choice)
-
-


### PR DESCRIPTION
# Hello Ama @khinezarthwe👋👋  : 

### I have changed the following in this PR:

- [ ]  I added two new methods `enable_questions` and `disable_questions` to the QuestionAdmin class. These methods use the update method to bulk update the `is_enabled` field for the selected questions. 
- [ ] In the admin interface, when you select one or more questions from the list and choose either "Enable selected questions" or "Disable selected questions" from the action dropdown, it will perform the bulk action to enable or disable the selected questions.
- [ ] You can check below the picture

![Screenshot (365)](https://github.com/khinezarthwe/mmdt_web_app/assets/118582316/77bb7ec9-3d5d-4759-ab19-2e446d2514e8)


![Screenshot (367)](https://github.com/khinezarthwe/mmdt_web_app/assets/118582316/0458fa8a-e659-4116-a2f2-1618e080e18e)


