### PR TITLE
Add active cohort check to renewal API

### DIFF
--- a/mmdt/api/schema.py
+++ b/mmdt/api/schema.py
@@ -202,7 +202,8 @@ class CustomSchemaGenerator(SchemaGenerator):
         get_op["summary"] = "Get user details by telegram username"
         get_op["description"] = (
             "Retrieve user information by their Telegram username. "
-            "Returns the same response format as the email lookup endpoint."
+            "Returns the same response format as the email lookup endpoint, "
+            "plus a registration_open flag indicating whether cohort registration is currently open."
         )
 
         params = get_op.setdefault("parameters", [])
@@ -241,6 +242,11 @@ class CustomSchemaGenerator(SchemaGenerator):
                                 "nullable": True,
                                 "description": "User subscription expiry date (ISO 8601 format) or null",
                                 "example": "2025-12-31T23:59:59Z",
+                            },
+                            "registration_open": {
+                                "type": "boolean",
+                                "description": "Whether cohort registration is currently open",
+                                "example": True,
                             },
                         },
                     },
@@ -356,14 +362,17 @@ class CustomSchemaGenerator(SchemaGenerator):
             "description": "Unauthorized - missing or invalid JWT token",
         }
         responses["403"] = {
-            "description": "Forbidden - user account is not active",
+            "description": "Forbidden - user account is not active or no active cohort registration window is open",
             "content": {
                 "application/json": {
                     "schema": {
                         "type": "object",
                         "properties": {
                             "status": {"type": "string", "example": "error"},
-                            "message": {"type": "string", "example": "User account is not active."},
+                            "message": {
+                                "type": "string",
+                                "description": "Either 'User account is not active.' or 'Registration is currently closed. No active cohort registration window is open.'",
+                            },
                         },
                     },
                 }

--- a/mmdt/api/views.py
+++ b/mmdt/api/views.py
@@ -10,7 +10,7 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import AccessToken
-from blog.models import SubscriberRequest 
+from blog.models import Cohort, SubscriberRequest
 from blog.google_api_utils import get_or_create_renewal_url
 from users.models import UserProfile
 
@@ -178,10 +178,13 @@ class UserDetailByTelegramView(APIView):
         except UserProfile.DoesNotExist:
             enddate = None
 
+        registration_open = Cohort.get_active_cohort() is not None
+
         logger.info("User detail returned for telegram=%s, email=%s, enddate=%s", telegram_name, user.email, enddate)
         return Response({
             "email": user.email,
             "enddate": enddate,
+            "registration_open": registration_open,
         })
 
 
@@ -204,6 +207,14 @@ class UserRenewalRequestView(APIView):
             return Response(
                 {"status": "error", "message": str(first_error)},
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        active_cohort = Cohort.get_active_cohort()
+        if not active_cohort:
+            logger.info("Renewal request rejected: no active cohort registration window is open")
+            return Response(
+                {"status": "error", "message": "Registration is currently closed. No active cohort registration window is open."},
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         email = serializer.validated_data.get("email")

--- a/mmdt/blog/tests.py
+++ b/mmdt/blog/tests.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -8,6 +9,8 @@ from django.utils import timezone
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.conf import settings
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import AccessToken
 
 from .models import Post, Comment, SubscriberRequest, Cohort
 from .forms import CommentForm, SubscriberRequestForm, FeedbackAnalyzerForm
@@ -750,3 +753,91 @@ class IntegrationTest(TestCase):
         self.assertEqual(subscriber.name, 'Integration Subscriber')
         self.assertEqual(subscriber.plan, 'annual')
         self.assertIsNotNone(subscriber.expiry_date)
+
+
+class CohortAPITests(TestCase):
+    """Test cases for cohort-related API behavior."""
+
+    def setUp(self):
+        patcher = patch(
+            'blog.signals.get_or_create_subscriber_folder_url',
+            return_value='https://drive.google.com/mock-folder',
+        )
+        self.mock_get_folder_url = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.client = APIClient()
+        self.admin_user = get_user_model().objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="admin-pass-123",
+        )
+
+        now = timezone.now()
+        self.cohort = Cohort.objects.create(
+            cohort_id='TEST_COHORT_API',
+            name='Test Cohort API',
+            reg_start_date=now - timedelta(days=1),
+            reg_end_date=now + timedelta(days=30),
+            exp_date_6=now + timedelta(days=180),
+            exp_date_12=now + timedelta(days=365),
+            is_active=True,
+        )
+
+        self.subscriber = SubscriberRequest.objects.create(
+            name='Cohort API User',
+            email='cohortapi@example.com',
+            country='Myanmar',
+            city='Yangon',
+            telegram_username='cohort_tg',
+            status='approved',
+            cohort=self.cohort,
+        )
+
+        self.user = get_user_model().objects.get(email='cohortapi@example.com')
+        self.user.profile.expiry_date = now + timedelta(days=30)
+        self.user.profile.save()
+
+        access_token = AccessToken.for_user(self.admin_user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+
+    def test_telegram_endpoint_registration_open(self):
+        """Telegram endpoint returns registration_open=True when an active cohort exists."""
+        response = self.client.get(
+            "/api/users/telegram", {"telegram_name": "cohort_tg"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data["registration_open"])
+
+    def test_telegram_endpoint_registration_closed(self):
+        """Telegram endpoint returns registration_open=False when no active cohort exists."""
+        self.cohort.is_active = False
+        self.cohort.save()
+
+        response = self.client.get(
+            "/api/users/telegram", {"telegram_name": "cohort_tg"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data["registration_open"])
+
+    @patch('api.views.get_or_create_renewal_url')
+    def test_renewal_rejected_when_no_active_cohort(self, mock_renewal_url):
+        """Renewal returns 403 when no active cohort registration window is open."""
+        self.cohort.is_active = False
+        self.cohort.save()
+
+        response = self.client.post(
+            "/api/user/request_renew",
+            {
+                "email": "cohortapi@example.com",
+                "telegram_name": "cohort_tg",
+                "plan": "6month",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data["status"], "error")
+        self.assertIn("Registration is currently closed", response.data["message"])


### PR DESCRIPTION
Reject renewal when no active cohort is open. Add registration_open flag to telegram lookup response.